### PR TITLE
Remove Updated GCIdentity Support and Add New ESX_Identity Script Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ FXServer ESX Police Job
 * Player management (boss actions and armory with buyable weapons)
   * esx_society => https://github.com/FXServer-ESX/fxserver-esx_society
   * esx_datastore => https://github.com/FXServer-ESX/fxserver-esx_datastore
+  
+* ESX Identity Support
+  * esx_identity => https://github.com/ArkSeyonet/fxserver-esx_identity
 
 [INSTALLATION]
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -668,7 +668,7 @@ end
 
 function OpenIdentityCardMenu(player)
 
-	if Config.EnableGCIdentity then
+	if Config.EnableESXIdentity then
 
 		ESX.TriggerServerCallback('esx_policejob:getOtherPlayerData', function(data)
 

--- a/config.lua
+++ b/config.lua
@@ -5,7 +5,7 @@ Config.MarkerSize                 = {x = 1.5, y = 1.5, z = 1.0}
 Config.MarkerColor                = {r = 50, g = 50, b = 204}
 Config.EnablePlayerManagement     = false
 Config.EnableArmoryManagement     = false
-Config.EnableESXIdentity          = false
+Config.EnableESXIdentity          = false -- only turn this on if you are using esx_identity
 Config.EnableNonFreemodePeds      = false -- turn this on if you want custom peds
 Config.EnableSocietyOwnedVehicles = false
 Config.MaxInService               = -1

--- a/config.lua
+++ b/config.lua
@@ -5,7 +5,7 @@ Config.MarkerSize                 = {x = 1.5, y = 1.5, z = 1.0}
 Config.MarkerColor                = {r = 50, g = 50, b = 204}
 Config.EnablePlayerManagement     = false
 Config.EnableArmoryManagement     = false
-Config.EnableESXIdentity           = false
+Config.EnableESXIdentity          = false
 Config.EnableNonFreemodePeds      = false -- turn this on if you want custom peds
 Config.EnableSocietyOwnedVehicles = false
 Config.MaxInService               = -1

--- a/config.lua
+++ b/config.lua
@@ -5,7 +5,7 @@ Config.MarkerSize                 = {x = 1.5, y = 1.5, z = 1.0}
 Config.MarkerColor                = {r = 50, g = 50, b = 204}
 Config.EnablePlayerManagement     = false
 Config.EnableArmoryManagement     = false
-Config.EnableGCIdentity           = false
+Config.EnableESXIdentity           = false
 Config.EnableNonFreemodePeds      = false -- turn this on if you want custom peds
 Config.EnableSocietyOwnedVehicles = false
 Config.MaxInService               = -1

--- a/localization/de_config.lua
+++ b/localization/de_config.lua
@@ -5,7 +5,7 @@ Config.MarkerSize                 = {x = 1.5, y = 1.5, z = 1.0}
 Config.MarkerColor                = {r = 50, g = 50, b = 204}
 Config.EnablePlayerManagement     = false
 Config.EnableArmoryManagement     = false
-Config.EnableESXIdentity          = false
+Config.EnableESXIdentity          = false -- only turn this on if you are using esx_identity
 Config.EnableNonFreemodePeds      = false -- turn this on if you want custom peds
 Config.EnableSocietyOwnedVehicles = false
 Config.MaxInService               = -1

--- a/localization/de_config.lua
+++ b/localization/de_config.lua
@@ -5,7 +5,7 @@ Config.MarkerSize                 = {x = 1.5, y = 1.5, z = 1.0}
 Config.MarkerColor                = {r = 50, g = 50, b = 204}
 Config.EnablePlayerManagement     = false
 Config.EnableArmoryManagement     = false
-Config.EnableGCIdentity           = false
+Config.EnableESXIdentity          = false
 Config.EnableNonFreemodePeds      = false -- turn this on if you want custom peds
 Config.EnableSocietyOwnedVehicles = false
 Config.MaxInService               = -1

--- a/localization/en_config.lua
+++ b/localization/en_config.lua
@@ -5,7 +5,7 @@ Config.MarkerSize                 = {x = 1.5, y = 1.5, z = 1.0}
 Config.MarkerColor                = {r = 50, g = 50, b = 204}
 Config.EnablePlayerManagement     = false
 Config.EnableArmoryManagement     = false
-Config.EnableESXIdentity          = false
+Config.EnableESXIdentity          = false -- only turn this on if you are using esx_identity
 Config.EnableNonFreemodePeds      = false -- turn this on if you want custom peds
 Config.EnableSocietyOwnedVehicles = false
 Config.MaxInService               = -1

--- a/localization/en_config.lua
+++ b/localization/en_config.lua
@@ -5,7 +5,7 @@ Config.MarkerSize                 = {x = 1.5, y = 1.5, z = 1.0}
 Config.MarkerColor                = {r = 50, g = 50, b = 204}
 Config.EnablePlayerManagement     = false
 Config.EnableArmoryManagement     = false
-Config.EnableGCIdentity           = false
+Config.EnableESXIdentity          = false
 Config.EnableNonFreemodePeds      = false -- turn this on if you want custom peds
 Config.EnableSocietyOwnedVehicles = false
 Config.MaxInService               = -1

--- a/server/main.lua
+++ b/server/main.lua
@@ -121,13 +121,13 @@ end)
 
 ESX.RegisterServerCallback('esx_policejob:getOtherPlayerData', function(source, cb, target)
 
-	if Config.EnableGCIdentity then
+	if Config.EnableESXIdentity then
 	
 		local xPlayer = ESX.GetPlayerFromId(target)
 		
 		local identifier = GetPlayerIdentifiers(target)[1]
 		
-		local result = MySQL.Sync.fetchAll("SELECT firstname, lastname, sex, dateofbirth, height FROM users WHERE identifier = @identifier", {
+		local result = MySQL.Sync.fetchAll("SELECT * FROM characters WHERE identifier = @identifier", {
 			['@identifier'] = identifier
 		})
 			
@@ -135,10 +135,10 @@ ESX.RegisterServerCallback('esx_policejob:getOtherPlayerData', function(source, 
 		local firstname 		= user['firstname']
 		local lastname  		= user['lastname']
 		local sex           		= user['sex']
-		local dob           		= tostring(user['dateofbirth'])
+		local dob           		= user['dateofbirth']
 		local heightInit    		= user['height']	
 		local heightFeet 		= tonumber(string.format("%.0f",heightInit / 12, 0))
-		local heightInches 		= heightInit % 12
+		local heightInches 		= tonumber(string.format("%.0f",heightInit % 12, 0))
 		local height 	   		= heightFeet .. "\' " .. heightInches .. "\""
 		
 		local data = {
@@ -214,7 +214,7 @@ end)
 
 ESX.RegisterServerCallback('esx_policejob:getVehicleInfos', function(source, cb, plate)
 
-	if Config.EnableGCIdentity then
+	if Config.EnableESXIdentity then
 	
 		MySQL.Async.fetchAll(
 			'SELECT * FROM owned_vehicles',
@@ -237,7 +237,7 @@ ESX.RegisterServerCallback('esx_policejob:getVehicleInfos', function(source, cb,
 				if foundIdentifier ~= nil then
 
 					MySQL.Async.fetchAll(
-						'SELECT * FROM users WHERE identifier = @identifier',
+						'SELECT * FROM characters WHERE identifier = @identifier',
 						{
 							['@identifier'] = foundIdentifier
 						},


### PR DESCRIPTION
Function: Player registers on first login, and with Config.EnableESXIdentity set to true the police F6 menu will reveal character names on ID Card and Vehicle Information.

Note: This version is my own script. If ESX github guys would like to fork my script to the main ESX github and change the esx_policejob readme.md to link there, I am fine with that.